### PR TITLE
updated the installer to call python instead of python3

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -12,8 +12,8 @@ def installerX():
     # extracted.zip https://drive.google.com/file/d/1HibfoC1LkHEUg8a5cU-gQNZ3C3rHbajK/view?usp=sharing
     # complete_repo https://drive.google.com/drive/folders/18VgVaxoDj531Imugoc_VvvTUzCvTQdZ9?usp=sharing
 
-    subprocess.check_call("python3 -m pip install -r requirements.txt", shell=True)
-    subprocess.check_call("python3 -m nltk.downloader all", shell=True)
+    subprocess.check_call("python -m pip install -r requirements.txt", shell=True)
+    subprocess.check_call("python -m nltk.downloader all", shell=True)
     from progress.bar import ChargingBar
     from zipfile38 import ZipFile
 

--- a/jarPhys-simple-installer.py
+++ b/jarPhys-simple-installer.py
@@ -4,8 +4,8 @@ import os
 import shutil
 import time
 
-subprocess.check_call("python3 -m pip install requests", shell=True)
-subprocess.check_call("python3 -m pip install zipfile38", shell=True)
+subprocess.check_call("python -m pip install requests", shell=True)
+subprocess.check_call("python -m pip install zipfile38", shell=True)
 
 import requests 
 from zipfile38 import ZipFile


### PR DESCRIPTION
The installer now calls `python -m pip...` instead of `python3 -m ...`. Allowing Window's users without python3 added to path to run the installer directly